### PR TITLE
Add basic GoJS frontend

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,32 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+#container {
+    display: flex;
+    height: 100vh;
+}
+.sidebar {
+    width: 150px;
+    border-right: 1px solid #ccc;
+}
+.main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+#diagramDiv {
+    flex: 1;
+    border: 1px solid #aaa;
+}
+.controls {
+    padding: 10px;
+    border-top: 1px solid #ccc;
+    display: flex;
+    gap: 10px;
+}
+#jsonText {
+    flex: 1;
+    height: 100px;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>SafeOps Flow Editor</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+</head>
+<body onload="init()">
+<div id="container">
+    <div id="palette" class="sidebar"></div>
+    <div class="main">
+        <div id="diagramDiv"></div>
+        <div class="controls">
+            <button id="saveBtn">Sauvegarder</button>
+            <button id="loadBtn">Charger</button>
+            <textarea id="jsonText" placeholder="JSON"></textarea>
+        </div>
+    </div>
+</div>
+<script src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,65 @@
+function init() {
+  const $ = go.GraphObject.make;
+
+  const diagram = $(go.Diagram, "diagramDiv", {
+    "undoManager.isEnabled": true
+  });
+
+  diagram.nodeTemplateMap.add("Normal",
+    $(go.Node, "Auto",
+      $(go.Shape, "RoundedRectangle", { fill: "lightblue" }),
+      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+    ));
+
+  diagram.nodeTemplateMap.add("Emergency",
+    $(go.Node, "Auto",
+      $(go.Shape, "RoundedRectangle", { fill: "orangered" }),
+      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+    ));
+
+  diagram.nodeTemplateMap.add("Decision",
+    $(go.Node, "Auto",
+      $(go.Shape, "Diamond", { fill: "lightyellow" }),
+      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+    ));
+
+  diagram.nodeTemplateMap.add("Alarm",
+    $(go.Node, "Auto",
+      $(go.Shape, "Triangle", { fill: "pink" }),
+      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+    ));
+
+  diagram.nodeTemplateMap.add("StartEnd",
+    $(go.Node, "Auto",
+      $(go.Shape, "Ellipse", { fill: "palegreen" }),
+      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+    ));
+
+  diagram.linkTemplate =
+    $(go.Link,
+      { routing: go.Link.AvoidsNodes, corner: 5 },
+      $(go.Shape),
+      $(go.Shape, { toArrow: "Standard" })
+    );
+
+  const palette = $(go.Palette, "palette", {
+    nodeTemplateMap: diagram.nodeTemplateMap
+  });
+
+  palette.model = new go.GraphLinksModel([
+    { category: "Normal", text: "Étape normale" },
+    { category: "Emergency", text: "Étape d'urgence" },
+    { category: "Decision", text: "Décision" },
+    { category: "Alarm", text: "Alarme" },
+    { category: "StartEnd", text: "Début/Fin" }
+  ]);
+
+  document.getElementById("saveBtn").addEventListener("click", () => {
+    document.getElementById("jsonText").value = diagram.model.toJson();
+  });
+
+  document.getElementById("loadBtn").addEventListener("click", () => {
+    const json = document.getElementById("jsonText").value;
+    if (json) diagram.model = go.Model.fromJson(json);
+  });
+}


### PR DESCRIPTION
## Summary
- add `index.html` page with GoJS integration
- include `css/style.css` for layout
- create `js/main.js` initializing diagram and palette

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880fe25858c83289c4e0b2acf0b9d1c