### PR TITLE
Add palette search and toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,3 +30,35 @@ body {
     flex: 1;
     height: 100px;
 }
+
+.hidden {
+    display: none;
+}
+
+.visible {
+    display: block;
+}
+
+#palette [title] {
+    position: relative;
+    cursor: help;
+}
+
+#palette [title]::after {
+    content: attr(title);
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.75);
+    color: #fff;
+    padding: 2px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+    display: none;
+    z-index: 10;
+}
+
+#palette [title]:hover::after {
+    display: block;
+}

--- a/index.html
+++ b/index.html
@@ -8,12 +8,16 @@
 </head>
 <body onload="init()">
 <div id="container">
-    <div id="palette" class="sidebar"></div>
+    <div id="paletteContainer" class="sidebar visible">
+        <input type="text" id="paletteSearch" placeholder="Rechercher...">
+        <div id="palette"></div>
+    </div>
     <div class="main">
         <div id="diagramDiv"></div>
         <div class="controls">
             <button id="saveBtn">Sauvegarder</button>
             <button id="loadBtn">Charger</button>
+            <button id="togglePaletteBtn">Masquer la palette</button>
             <textarea id="jsonText" placeholder="JSON"></textarea>
         </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -7,30 +7,40 @@ function init() {
 
   diagram.nodeTemplateMap.add("Normal",
     $(go.Node, "Auto",
+      { title: "" },
+      new go.Binding("title", "text"),
       $(go.Shape, "RoundedRectangle", { fill: "lightblue" }),
       $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
     ));
 
   diagram.nodeTemplateMap.add("Emergency",
     $(go.Node, "Auto",
+      { title: "" },
+      new go.Binding("title", "text"),
       $(go.Shape, "RoundedRectangle", { fill: "orangered" }),
       $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
     ));
 
   diagram.nodeTemplateMap.add("Decision",
     $(go.Node, "Auto",
+      { title: "" },
+      new go.Binding("title", "text"),
       $(go.Shape, "Diamond", { fill: "lightyellow" }),
       $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
     ));
 
   diagram.nodeTemplateMap.add("Alarm",
     $(go.Node, "Auto",
+      { title: "" },
+      new go.Binding("title", "text"),
       $(go.Shape, "Triangle", { fill: "pink" }),
       $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
     ));
 
   diagram.nodeTemplateMap.add("StartEnd",
     $(go.Node, "Auto",
+      { title: "" },
+      new go.Binding("title", "text"),
       $(go.Shape, "Ellipse", { fill: "palegreen" }),
       $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
     ));
@@ -46,13 +56,15 @@ function init() {
     nodeTemplateMap: diagram.nodeTemplateMap
   });
 
-  palette.model = new go.GraphLinksModel([
+  const paletteData = [
     { category: "Normal", text: "Étape normale" },
     { category: "Emergency", text: "Étape d'urgence" },
     { category: "Decision", text: "Décision" },
     { category: "Alarm", text: "Alarme" },
     { category: "StartEnd", text: "Début/Fin" }
-  ]);
+  ];
+
+  palette.model = new go.GraphLinksModel(paletteData);
 
   document.getElementById("saveBtn").addEventListener("click", () => {
     document.getElementById("jsonText").value = diagram.model.toJson();
@@ -61,5 +73,25 @@ function init() {
   document.getElementById("loadBtn").addEventListener("click", () => {
     const json = document.getElementById("jsonText").value;
     if (json) diagram.model = go.Model.fromJson(json);
+  });
+
+  const searchInput = document.getElementById("paletteSearch");
+  searchInput.addEventListener("input", (e) => {
+    const term = e.target.value.toLowerCase();
+    const filtered = paletteData.filter(d =>
+      d.text.toLowerCase().includes(term)
+    );
+    palette.model = new go.GraphLinksModel(filtered);
+  });
+
+  const paletteContainer = document.getElementById("paletteContainer");
+  const toggleBtn = document.getElementById("togglePaletteBtn");
+  toggleBtn.addEventListener("click", () => {
+    paletteContainer.classList.toggle("hidden");
+    if (paletteContainer.classList.contains("hidden")) {
+      toggleBtn.textContent = "Afficher la palette";
+    } else {
+      toggleBtn.textContent = "Masquer la palette";
+    }
   });
 }


### PR DESCRIPTION
## Summary
- add palette search and toggle button
- style hidden/visible states and tooltips
- filter palette items in JS
- apply `title` attributes to palette nodes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68810859d1d48328bc5f9eb96176ea59