### PR TITLE
Add export and edit controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,6 +26,18 @@ body {
     display: flex;
     gap: 10px;
 }
+
+.controls button {
+    padding: 5px 10px;
+    background-color: #eee;
+    border: 1px solid #999;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.controls button:hover {
+    background-color: #ddd;
+}
 #jsonText {
     flex: 1;
     height: 100px;

--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
         <div class="controls">
             <button id="saveBtn">Sauvegarder</button>
             <button id="loadBtn">Charger</button>
+            <button id="undoBtn">Annuler</button>
+            <button id="redoBtn">Rétablir</button>
+            <button id="clearBtn">Effacer</button>
+            <button id="pngBtn">Export PNG</button>
+            <button id="svgBtn">Export SVG</button>
             <textarea id="jsonText" placeholder="JSON"></textarea>
         </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -62,4 +62,28 @@ function init() {
     const json = document.getElementById("jsonText").value;
     if (json) diagram.model = go.Model.fromJson(json);
   });
+
+  document.getElementById("undoBtn").addEventListener("click", () => {
+    if (diagram.undoManager.canUndo()) diagram.undoManager.undo();
+  });
+
+  document.getElementById("redoBtn").addEventListener("click", () => {
+    if (diagram.undoManager.canRedo()) diagram.undoManager.redo();
+  });
+
+  document.getElementById("clearBtn").addEventListener("click", () => {
+    diagram.model = new go.GraphLinksModel();
+  });
+
+  document.getElementById("pngBtn").addEventListener("click", () => {
+    const img = diagram.makeImage({ background: "white" });
+    const w = window.open("");
+    if (w) w.document.body.appendChild(img);
+  });
+
+  document.getElementById("svgBtn").addEventListener("click", () => {
+    const svg = diagram.makeSvg({ background: "white" });
+    const w = window.open("");
+    if (w) w.document.body.appendChild(svg);
+  });
 }


### PR DESCRIPTION
## Summary
- add new controls for undo/redo, clearing canvas, and exporting diagram as PNG or SVG
- style toolbar buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881086ada30832882f343b850b0baff