### PR TITLE
Add theme switching with dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,31 @@
+# Default light theme variables
+:root {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+    --node-normal-color: lightblue;
+    --node-emergency-color: orangered;
+    --node-decision-color: lightyellow;
+    --node-alarm-color: pink;
+    --node-startend-color: palegreen;
+}
+
 body {
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+/* Dark theme overrides */
+[data-theme="dark"] {
+    --bg-color: #222222;
+    --text-color: #eeeeee;
+    --node-normal-color: #3a6ea5;
+    --node-emergency-color: #ff6347;
+    --node-decision-color: #bdb76b;
+    --node-alarm-color: #c71585;
+    --node-startend-color: #228b22;
 }
 #container {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="css/style.css">
     <script src="https://unpkg.com/gojs/release/go.js"></script>
 </head>
-<body onload="init()">
+<body data-theme="light" onload="init()">
 <div id="container">
     <div id="palette" class="sidebar"></div>
     <div class="main">
@@ -14,6 +14,7 @@
         <div class="controls">
             <button id="saveBtn">Sauvegarder</button>
             <button id="loadBtn">Charger</button>
+            <button id="themeToggle">Thème sombre</button>
             <textarea id="jsonText" placeholder="JSON"></textarea>
         </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,38 +1,65 @@
+let diagram;
+let currentTheme = 'light';
+
+function getCSSVar(name) {
+  return getComputedStyle(document.body).getPropertyValue(name).trim();
+}
+
+function applyTheme() {
+  if (!diagram) return;
+  diagram.nodeTemplateMap.get("Normal").findObject("SHAPE").fill = getCSSVar('--node-normal-color');
+  diagram.nodeTemplateMap.get("Emergency").findObject("SHAPE").fill = getCSSVar('--node-emergency-color');
+  diagram.nodeTemplateMap.get("Decision").findObject("SHAPE").fill = getCSSVar('--node-decision-color');
+  diagram.nodeTemplateMap.get("Alarm").findObject("SHAPE").fill = getCSSVar('--node-alarm-color');
+  diagram.nodeTemplateMap.get("StartEnd").findObject("SHAPE").fill = getCSSVar('--node-startend-color');
+
+  ['Normal','Emergency','Decision','Alarm','StartEnd'].forEach(cat => {
+    diagram.nodeTemplateMap.get(cat).findObject("TEXT").stroke = getCSSVar('--text-color');
+  });
+  diagram.requestUpdate();
+}
+
 function init() {
   const $ = go.GraphObject.make;
 
-  const diagram = $(go.Diagram, "diagramDiv", {
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme) {
+    currentTheme = savedTheme;
+    document.body.setAttribute('data-theme', currentTheme);
+  }
+
+  diagram = $(go.Diagram, "diagramDiv", {
     "undoManager.isEnabled": true
   });
 
   diagram.nodeTemplateMap.add("Normal",
     $(go.Node, "Auto",
-      $(go.Shape, "RoundedRectangle", { fill: "lightblue" }),
-      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+      $(go.Shape, "RoundedRectangle", { name: "SHAPE", fill: getCSSVar('--node-normal-color') }),
+      $(go.TextBlock, { name: "TEXT", margin: 6, stroke: getCSSVar('--text-color') }, new go.Binding("text", "text"))
     ));
 
   diagram.nodeTemplateMap.add("Emergency",
     $(go.Node, "Auto",
-      $(go.Shape, "RoundedRectangle", { fill: "orangered" }),
-      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+      $(go.Shape, "RoundedRectangle", { name: "SHAPE", fill: getCSSVar('--node-emergency-color') }),
+      $(go.TextBlock, { name: "TEXT", margin: 6, stroke: getCSSVar('--text-color') }, new go.Binding("text", "text"))
     ));
 
   diagram.nodeTemplateMap.add("Decision",
     $(go.Node, "Auto",
-      $(go.Shape, "Diamond", { fill: "lightyellow" }),
-      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+      $(go.Shape, "Diamond", { name: "SHAPE", fill: getCSSVar('--node-decision-color') }),
+      $(go.TextBlock, { name: "TEXT", margin: 6, stroke: getCSSVar('--text-color') }, new go.Binding("text", "text"))
     ));
 
   diagram.nodeTemplateMap.add("Alarm",
     $(go.Node, "Auto",
-      $(go.Shape, "Triangle", { fill: "pink" }),
-      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+      $(go.Shape, "Triangle", { name: "SHAPE", fill: getCSSVar('--node-alarm-color') }),
+      $(go.TextBlock, { name: "TEXT", margin: 6, stroke: getCSSVar('--text-color') }, new go.Binding("text", "text"))
     ));
 
   diagram.nodeTemplateMap.add("StartEnd",
     $(go.Node, "Auto",
-      $(go.Shape, "Ellipse", { fill: "palegreen" }),
-      $(go.TextBlock, { margin: 6 }, new go.Binding("text", "text"))
+      $(go.Shape, "Ellipse", { name: "SHAPE", fill: getCSSVar('--node-startend-color') }),
+      $(go.TextBlock, { name: "TEXT", margin: 6, stroke: getCSSVar('--text-color') }, new go.Binding("text", "text"))
     ));
 
   diagram.linkTemplate =
@@ -62,4 +89,13 @@ function init() {
     const json = document.getElementById("jsonText").value;
     if (json) diagram.model = go.Model.fromJson(json);
   });
+
+  document.getElementById("themeToggle").addEventListener("click", () => {
+    currentTheme = currentTheme === 'light' ? 'dark' : 'light';
+    document.body.setAttribute('data-theme', currentTheme);
+    localStorage.setItem('theme', currentTheme);
+    applyTheme();
+  });
+
+  applyTheme();
 }


### PR DESCRIPTION
## Summary
- define CSS variables and dark theme overrides
- implement theme loading and switching logic in main.js
- add theme toggle button in the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881086f291883288db4ee84246babdf