### PR TITLE
Add GoJS overview window

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,6 +15,7 @@ body {
     flex: 1;
     display: flex;
     flex-direction: column;
+    position: relative;
 }
 #diagramDiv {
     flex: 1;
@@ -29,4 +30,14 @@ body {
 #jsonText {
     flex: 1;
     height: 100px;
+}
+
+#overviewDiv {
+    width: 150px;
+    height: 150px;
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    border: 1px solid #aaa;
+    background: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div id="palette" class="sidebar"></div>
     <div class="main">
         <div id="diagramDiv"></div>
+        <div id="overviewDiv"></div>
         <div class="controls">
             <button id="saveBtn">Sauvegarder</button>
             <button id="loadBtn">Charger</button>

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,8 @@ function init() {
     "undoManager.isEnabled": true
   });
 
+  const overview = $(go.Overview, "overviewDiv", { observed: diagram });
+
   diagram.nodeTemplateMap.add("Normal",
     $(go.Node, "Auto",
       $(go.Shape, "RoundedRectangle", { fill: "lightblue" }),


### PR DESCRIPTION
## Summary
- add overview div for diagram
- wire up go.Overview in `init`
- style overview window

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6881087417d483289662efbbb2616fc0