### PR TITLE
Add Firebase authentication demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # safeops-webtool
+
 Project to develop a web application for graphical creation of operating instructions for an industrial unit.
+
+## Authentication
+
+The project now includes a small demo using Firebase Authentication. `auth.html` contains forms for account creation and login. Users must verify their email address before they can access the main Carrd site.
+
+To enable authentication replace the placeholders in `js/auth.js` with your Firebase configuration values.

--- a/auth.html
+++ b/auth.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SafeOps Authentication</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <h1>Account Access</h1>
+    <div id="feedback"></div>
+    <h2>Register</h2>
+    <form id="registerForm">
+        <input type="email" id="registerEmail" placeholder="Email" required><br>
+        <input type="password" id="registerPassword" placeholder="Password" required><br>
+        <button type="submit">Register</button>
+    </form>
+    <h2>Login</h2>
+    <form id="loginForm">
+        <input type="email" id="loginEmail" placeholder="Email" required><br>
+        <input type="password" id="loginPassword" placeholder="Password" required><br>
+        <button type="submit">Login</button>
+    </form>
+
+    <script type="module" src="js/auth.js"></script>
+</body>
+</html>

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,48 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js';
+import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+
+// TODO: Replace the configuration with your Firebase project settings
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  appId: 'YOUR_APP_ID'
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+
+const feedback = document.getElementById('feedback');
+
+// Registration
+const regForm = document.getElementById('registerForm');
+regForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('registerEmail').value;
+  const password = document.getElementById('registerPassword').value;
+  try {
+    const cred = await createUserWithEmailAndPassword(auth, email, password);
+    await cred.user.sendEmailVerification();
+    feedback.textContent = 'Account created. Please verify your email.';
+  } catch (err) {
+    feedback.textContent = err.message;
+  }
+});
+
+// Login
+const loginForm = document.getElementById('loginForm');
+loginForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('loginEmail').value;
+  const password = document.getElementById('loginPassword').value;
+  try {
+    const cred = await signInWithEmailAndPassword(auth, email, password);
+    if (cred.user.emailVerified) {
+      window.location.href = 'https://safeops.carrd.co/';
+    } else {
+      feedback.textContent = 'Please verify your email before logging in.';
+    }
+  } catch (err) {
+    feedback.textContent = err.message;
+  }
+});


### PR DESCRIPTION
## Summary
- add a simple `auth.html` page with register and login forms
- implement Firebase auth logic in `js/auth.js`
- document authentication setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888dae686208328b7f2f551c5b60621